### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ Pillow
 colorama
 git+https://github.com/SillyLossy/poe-api
 --extra-index-url https://download.pytorch.org/whl/cu117
-torch==1.13.1+cu117
+torch==2.0.0
 git+https://github.com/huggingface/transformers


### PR DESCRIPTION
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
torchvision 0.15.1 requires torch==2.0.0, but you have torch 1.13.1+cu117 which is incompatible.
torchaudio 2.0.1 requires torch==2.0.0, but you have torch 1.13.1+cu117 which is incompatible.